### PR TITLE
Change import logic to fetch only after displaying feedback

### DIFF
--- a/src/components/animations/FadeInAnimation.js
+++ b/src/components/animations/FadeInAnimation.js
@@ -1,6 +1,21 @@
 import PropTypes from 'prop-types';
 import React, { PureComponent } from 'react';
-import { Animated, Easing } from 'react-native';
+import Animated, { Easing } from 'react-native-reanimated';
+import { InteractionManager } from 'react-native';
+
+const {
+  set,
+  cond,
+  startClock,
+  stopClock,
+  clockRunning,
+  block,
+  timing,
+  call,
+  Value,
+  Clock,
+} = Animated;
+
 
 export default class FadeInAnimation extends PureComponent {
   static propTypes = {
@@ -8,6 +23,7 @@ export default class FadeInAnimation extends PureComponent {
     duration: PropTypes.number,
     easing: PropTypes.func,
     from: PropTypes.number,
+    isInteraction: PropTypes.boolean,
     style: PropTypes.object,
     to: PropTypes.number,
   }
@@ -16,40 +32,58 @@ export default class FadeInAnimation extends PureComponent {
     duration: 250,
     easing: Easing.quad,
     from: 0,
+    isInteraction: false,
     to: 1,
   }
 
-  animatedOpacity = new Animated.Value(0)
+  runTiming = () => {
+    const {
+      to, easing, from, duration, isInteraction,
+    } = this.props;
 
-  componentDidMount = () => {
-    const { duration, easing, to } = this.props;
+    const handle = isInteraction && InteractionManager.createInteractionHandle();
 
-    Animated.timing(this.animatedOpacity, {
+    const state = {
+      finished: new Value(0),
+      frameTime: new Value(0),
+      position: new Value(0),
+      time: new Value(0),
+    };
+
+    const clock = new Clock();
+
+    const config = {
       duration,
       easing,
-      isInteraction: false,
-      toValue: to,
-      useNativeDriver: true,
-    }).start();
+      toValue: new Value(0),
+    };
+
+    return block([
+      cond(clockRunning(clock), 0, [
+        set(state.finished, 0),
+        set(state.time, 0),
+        set(state.position, from),
+        set(state.frameTime, 0),
+        set(config.toValue, to),
+        startClock(clock),
+      ]),
+      timing(clock, state, config),
+      cond(state.finished, [
+        stopClock(clock),
+        call([], () => isInteraction && InteractionManager.clearInteractionHandle(handle)),
+      ]),
+      state.position,
+    ]);
   }
 
-  componentWillUnmount = () => this.animatedOpacity.stopAnimation()
-
-  interpolatedAnimation = () => {
-    const { from, to } = this.props;
-
-    return this.animatedOpacity.interpolate({
-      inputRange: [0, 1],
-      outputRange: [from, to],
-    });
-  }
+  animatedOpacity = this.runTiming();
 
   render = () => (
     <Animated.View
       {...this.props}
       style={[
         this.props.style,
-        { opacity: this.interpolatedAnimation() },
+        { opacity: this.animatedOpacity },
       ]}
     />
   )

--- a/src/components/modal/LoadingOverlay.js
+++ b/src/components/modal/LoadingOverlay.js
@@ -32,7 +32,9 @@ const LoadingOverlay = ({ title }) => (
     disabled={true}
     zIndex={999}
   >
-    <FadeInAnimation>
+    <FadeInAnimation
+      isInteraction
+    >
       <Overlay
         blurAmount={20}
         blurType="light"

--- a/src/screens/ImportSeedPhraseSheetWithData.js
+++ b/src/screens/ImportSeedPhraseSheetWithData.js
@@ -92,7 +92,7 @@ const ImportSeedPhraseSheetWithData = compose(
       }
 
       if (!prevProps.isImporting && isImporting) {
-        importSeedPhrase();
+        InteractionManager.runAfterInteractions(importSeedPhrase);
       }
     },
   }),


### PR DESCRIPTION
## Motivation
Changing state ought to be considered as async action and then other operations (i.e. fetching) have to wait for it in order to omit race condition. Previously fetching was probably conflicting with displaying feedback.

## Changes 
https://github.com/neoziro/recompact/issues/59
Following this discussion figured out that lifecycle methods' hook is a solution for this case since `compact` does not provide any mechanism for registering proper callback. There was need to make fetch only after state's change. 

Also, change fading logic and make it more smooth. 