### PR TITLE
Make touches on button exclusive

### DIFF
--- a/src/components/animations/ButtonPressAnimation.js
+++ b/src/components/animations/ButtonPressAnimation.js
@@ -71,7 +71,7 @@ export default class ButtonPressAnimation extends PureComponent {
     const isActive = state === State.BEGAN;
 
     if (buttonExcludingMutex !== this) {
-      if (buttonExcludingMutex === null) {
+      if (buttonExcludingMutex === null && isActive) {
         buttonExcludingMutex = this;
       } else {
         return;

--- a/src/components/animations/ButtonPressAnimation.js
+++ b/src/components/animations/ButtonPressAnimation.js
@@ -15,6 +15,8 @@ const DefaultAnimatedValues = {
   transX: 0,
 };
 
+let buttonExcludingMutex = null;
+
 export default class ButtonPressAnimation extends PureComponent {
   static propTypes = {
     activeOpacity: PropTypes.number,
@@ -67,6 +69,17 @@ export default class ButtonPressAnimation extends PureComponent {
     const { scaleOffsetX } = this.state;
 
     const isActive = state === State.BEGAN;
+
+    if (buttonExcludingMutex !== this) {
+      if (buttonExcludingMutex === null) {
+        buttonExcludingMutex = this;
+      } else {
+        return;
+      }
+    }
+    if (state === State.END || state === State.FAILED || state === State.CANCELLED) {
+      buttonExcludingMutex = null;
+    }
 
     const animationsArray = [
       // Default spring animation

--- a/src/screens/ExpandedAssetScreen.js
+++ b/src/screens/ExpandedAssetScreen.js
@@ -8,6 +8,7 @@ import {
   pure,
   withHandlers,
   withProps,
+  shouldUpdate,
 } from 'recompact';
 import { createSelector } from 'reselect';
 import styled from 'styled-components/primitives';
@@ -91,4 +92,5 @@ export default compose(
   withProps(buildExpandedAssetsSelector),
   withHandlers({ onPressBackground: ({ navigation }) => () => navigation.goBack() }),
   pure,
+  shouldUpdate(() => false),
 )(ExpandedAssetScreen);

--- a/src/screens/ExpandedAssetScreen.js
+++ b/src/screens/ExpandedAssetScreen.js
@@ -5,7 +5,6 @@ import { StatusBar } from 'react-native';
 import {
   compose,
   defaultProps,
-  pure,
   withHandlers,
   withProps,
   shouldUpdate,
@@ -91,6 +90,5 @@ export default compose(
   withAccountAssets,
   withProps(buildExpandedAssetsSelector),
   withHandlers({ onPressBackground: ({ navigation }) => () => navigation.goBack() }),
-  pure,
   shouldUpdate(() => false),
 )(ExpandedAssetScreen);


### PR DESCRIPTION
Please consider that solution as a temporary fix. In future I wish to use specific touchable done with RNGH's `GenericTouchable`
However, in order to make it work properly, we have to change a little bit behavior of RNGH buttons, which I hope will be merged today (https://github.com/kmagiera/react-native-gesture-handler/pull/454/files @kmagiera 🙏).

We observed that it is very expected behavior in iOS to respond for only one button and then we want to export `exclusive` prop in RNGH's button (and set it as default) 