### PR TITLE
moved out init functions to App and removed initial loading of multiple WalletScreens

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -52,6 +52,7 @@ class App extends Component {
     addTransactionsToApprove: PropTypes.func,
     addTransactionToApprove: PropTypes.func,
     getValidWalletConnectors: PropTypes.func,
+    onHideSplashScreen: PropTypes.func,
     refreshAccount: PropTypes.func,
     settingsInitializeState: PropTypes.func,
     settingsUpdateAccountAddress: PropTypes.func,
@@ -158,7 +159,7 @@ class App extends Component {
   handleOpenConfirmTransactionModal = (transactionDetails, autoOpened) => {
     if (!this.navigatorRef) return;
     const action = StackActions.push({
-      params: { transactionDetails, autoOpened },
+      params: { autoOpened, transactionDetails },
       routeName: 'ConfirmRequest',
     });
     Navigation.handleAction(this.navigatorRef, action);

--- a/src/App.js
+++ b/src/App.js
@@ -18,6 +18,8 @@ import { compose, withProps } from 'recompact';
 import { FlexItem } from './components/layout';
 import OfflineBadge from './components/OfflineBadge';
 import {
+  withAccountRefresh,
+  withHideSplashScreen,
   withTrackingDate,
   withWalletConnectConnections,
 } from './hoc';
@@ -50,6 +52,7 @@ class App extends Component {
     addTransactionsToApprove: PropTypes.func,
     addTransactionToApprove: PropTypes.func,
     getValidWalletConnectors: PropTypes.func,
+    refreshAccount: PropTypes.func,
     settingsInitializeState: PropTypes.func,
     settingsUpdateAccountAddress: PropTypes.func,
     setWalletConnectors: PropTypes.func,
@@ -64,6 +67,9 @@ class App extends Component {
   navigatorRef = null
 
   async componentDidMount() {
+    await this.handleWalletConfig();
+    this.props.onHideSplashScreen();
+    await this.props.refreshAccount();
     Piwik.initTracker('https://matomo.balance.io/piwik.php', 2);
     AppState.addEventListener('change', this.handleAppStateChange);
     firebase.messaging().getToken()
@@ -216,6 +222,8 @@ class App extends Component {
 
 const AppWithRedux = compose(
   withProps({ store }),
+  withAccountRefresh,
+  withHideSplashScreen,
   withTrackingDate,
   withWalletConnectConnections,
   connect(

--- a/src/navigation/navigators/createSwipeNavigator.js
+++ b/src/navigation/navigators/createSwipeNavigator.js
@@ -137,14 +137,11 @@ export default function createSwipeNavigator(screens, options) {
     /**
      * Scroll to the initial route provided in createSwipeNavigator options
      * when the view is rendered and sizing is calculated.
-     * Replace initial screens with the final screens.
      */
     onLayout = () => {
       const routeIndex = this.getRouteIndex(options.initialRouteName);
 
       this.scrollToIndex(routeIndex, false);
-
-      this.setState({ flatListScreens: loadedScreens });
     }
 
     /**

--- a/src/navigation/navigators/createSwipeNavigator.js
+++ b/src/navigation/navigators/createSwipeNavigator.js
@@ -10,7 +10,6 @@ const EMPTY_ARRAY = [];
 export default function createSwipeNavigator(screens, options) {
   const router = StackRouter(screens, options);
   const routeOrder = options.order || map(screens, ({ name }) => name);
-  const initialScreens = map(screens, () => screens[options.initialRouteName]);
   const loadedScreens = map(screens, (screen) => screen);
   const onSwipeStart = options.onSwipeStart || function noop() {};
   const onSwipeEnd = options.onSwipeEnd || function noop() {};
@@ -27,7 +26,7 @@ export default function createSwipeNavigator(screens, options) {
 
     state = {
       currentIndex: 0,
-      flatListScreens: initialScreens,
+      flatListScreens: loadedScreens,
       scrollEnabled: true,
     };
 

--- a/src/screens/WalletScreen.js
+++ b/src/screens/WalletScreen.js
@@ -22,7 +22,6 @@ import {
   withAccountSettings,
   withBlurTransitionProps,
   withFetchingPrices,
-  withHideSplashScreen,
   withIsWalletEmpty,
   withTrackingDate,
 } from '../hoc';
@@ -37,7 +36,6 @@ class WalletScreen extends PureComponent {
     isEmpty: PropTypes.bool.isRequired,
     isScreenActive: PropTypes.bool,
     navigation: PropTypes.object,
-    onHideSplashScreen: PropTypes.func,
     onRefreshList: PropTypes.func.isRequired,
     refreshAccount: PropTypes.func,
     sections: PropTypes.array,
@@ -49,16 +47,7 @@ class WalletScreen extends PureComponent {
   }
 
   componentDidMount = async () => {
-    const {
-      navigation,
-      onHideSplashScreen,
-      refreshAccount,
-      toggleShowShitcoins,
-    } = this.props;
-
-    // Initialize wallet
-    const { handleWalletConfig } = navigation.getScreenProps();
-    await handleWalletConfig();
+    const { toggleShowShitcoins } = this.props;
 
     try {
       const showShitcoins = await getShowShitcoinsSetting();
@@ -68,9 +57,6 @@ class WalletScreen extends PureComponent {
     } catch (error) {
       // TODO
     }
-
-    onHideSplashScreen();
-    await refreshAccount();
   }
 
   componentDidUpdate = (prevProps) => {
@@ -134,7 +120,6 @@ export default compose(
   withAccountSettings,
   withFetchingPrices,
   withTrackingDate,
-  withHideSplashScreen,
   withBlurTransitionProps,
   withIsWalletEmpty,
   withState('showShitcoins', 'toggleShowShitcoins', true),


### PR DESCRIPTION
- WalletScreen being loaded multiple times because of "initial screens" were all pointing to WalletScreen
- We can just load the screens but the initial screen will be resolved without having to set all the screens to WalletScreen initially
- Also moved out the 'wallet initialization' logic that should only happen once to the App level instead of WalletScreen level