### PR TITLE
Add spinner for fetching transactions

### DIFF
--- a/src/hoc/withAccountRefresh.js
+++ b/src/hoc/withAccountRefresh.js
@@ -10,7 +10,6 @@ export default Component => compose(
   withHandlers({
     refreshAccount: (ownProps) => async () => {
       try {
-        console.log(ownProps);
         await ownProps.assetsRefreshState();
         ownProps.setAssetsFetched();
         await ownProps.transactionsRefreshState();

--- a/src/hoc/withAccountRefresh.js
+++ b/src/hoc/withAccountRefresh.js
@@ -1,14 +1,20 @@
 import { assetsRefreshState, transactionsRefreshState } from 'balance-common';
 import { connect } from 'react-redux';
 import { compose, withHandlers } from 'recompact';
+import { setAssetsFetched, setTransactionFetched } from '../redux/initialFetch';
 
 export default Component => compose(
-  connect(null, { assetsRefreshState, transactionsRefreshState }),
+  connect(null, {
+    assetsRefreshState, setAssetsFetched, setTransactionFetched, transactionsRefreshState,
+  }),
   withHandlers({
     refreshAccount: (ownProps) => async () => {
       try {
+        console.log(ownProps);
         await ownProps.assetsRefreshState();
+        ownProps.setAssetsFetched();
         await ownProps.transactionsRefreshState();
+        ownProps.setTransactionFetched();
       } catch (error) {
         // TODO more granular error messaging depending on offline status
       }

--- a/src/hoc/withAreTransactionsFetched.js
+++ b/src/hoc/withAreTransactionsFetched.js
@@ -1,0 +1,6 @@
+import { connect } from 'react-redux';
+import { FETCHED_TRANSACTIONS } from '../redux/initialFetch';
+
+const mapStateToProps = ({ initialFetch: { fetchingState } }) => ({ areTransactionsFetched: fetchingState === FETCHED_TRANSACTIONS });
+
+export default Component => connect(mapStateToProps)(Component);

--- a/src/hoc/withAreTransactionsFetching.js
+++ b/src/hoc/withAreTransactionsFetching.js
@@ -1,6 +1,0 @@
-import { connect } from 'react-redux';
-import { FETCHED_ASSETS } from '../redux/initialFetch';
-
-const mapStateToProps = ({ initialFetch: { fetchingState } }) => ({ areTransactionsFetching: fetchingState === FETCHED_ASSETS });
-
-export default Component => connect(mapStateToProps)(Component);

--- a/src/hoc/withAreTransactionsFetching.js
+++ b/src/hoc/withAreTransactionsFetching.js
@@ -1,0 +1,6 @@
+import { connect } from 'react-redux';
+import { FETCHED_ASSETS } from '../redux/initialFetch';
+
+const mapStateToProps = ({ initialFetch: { fetchingState } }) => ({ areTransactionsFetching: fetchingState === FETCHED_ASSETS });
+
+export default Component => connect(mapStateToProps)(Component);

--- a/src/redux/initialFetch.js
+++ b/src/redux/initialFetch.js
@@ -1,0 +1,32 @@
+// -- Constants --------------------------------------- //
+const SET_ASSETS_FETCHED = 'initialFetch/SET_ASSETS_FETCH';
+const SET_TRANSACTIONS_FETCHED = 'initialFetch/SET_TRANSACTIONS_FETCHED';
+const NOTHING_FETCHED = 0;
+export const FETCHED_ASSETS = 1;
+const FETCHED_TRANSACTIONS = 2;
+
+export const setTransactionFetched = () => (dispatch, getState) => {
+  if (getState().initialFetch.fetchingState === FETCHED_ASSETS) {
+    dispatch({ type: SET_TRANSACTIONS_FETCHED });
+  }
+};
+
+export const setAssetsFetched = () => (dispatch, getState) => {
+  if (getState().initialFetch.fetchingState === NOTHING_FETCHED) {
+    dispatch({ type: SET_ASSETS_FETCHED });
+  }
+};
+
+// -- Reducer ----------------------------------------- //
+const INITIAL_STATE = { fetchingState: NOTHING_FETCHED };
+
+export default (state = INITIAL_STATE, action) => {
+  switch (action.type) {
+  case SET_ASSETS_FETCHED:
+    return { fetchingState: FETCHED_ASSETS };
+  case SET_TRANSACTIONS_FETCHED:
+    return { fetchingState: FETCHED_TRANSACTIONS };
+  default:
+    return state;
+  }
+};

--- a/src/redux/initialFetch.js
+++ b/src/redux/initialFetch.js
@@ -2,8 +2,8 @@
 const SET_ASSETS_FETCHED = 'initialFetch/SET_ASSETS_FETCH';
 const SET_TRANSACTIONS_FETCHED = 'initialFetch/SET_TRANSACTIONS_FETCHED';
 const NOTHING_FETCHED = 0;
-export const FETCHED_ASSETS = 1;
-const FETCHED_TRANSACTIONS = 2;
+const FETCHED_ASSETS = 1;
+export const FETCHED_TRANSACTIONS = 2;
 
 export const setTransactionFetched = () => (dispatch, getState) => {
   if (getState().initialFetch.fetchingState === FETCHED_ASSETS) {

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -11,6 +11,7 @@ import actionSheetManager from './actionSheetManager';
 import imageDimensionsCache from './imageDimensionsCache';
 import isWalletEmpty from './isWalletEmpty';
 import navigation from './navigation';
+import initialFetch from './initialFetch';
 import nonce from './nonce';
 import tracking from './tracking';
 import transactionsToApprove from './transactionsToApprove';
@@ -20,6 +21,7 @@ export default combineReducers({
   actionSheetManager,
   assets,
   imageDimensionsCache,
+  initialFetch,
   isWalletEmpty,
   navigation,
   nonce,

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -13,7 +13,7 @@ import { LoadingOverlay } from '../components/modal';
 
 const ProfileScreen = ({
   accountAddress,
-  areTransactionsFetching,
+  areTransactionsFetched,
   blurOpacity,
   hasPendingTransaction,
   isEmpty,
@@ -25,49 +25,54 @@ const ProfileScreen = ({
   showBlur,
   transactions,
   transactionsCount,
-}) => (
-  <Page component={FlexItem} style={position.sizeAsObject('100%')}>
-    {showBlur && (
-      <FadeInAnimation duration={200} style={{ ...position.coverAsObject, zIndex: 1 }}>
-        <BlurOverlay
-          backgroundColor={colors.alpha(colors.blueGreyDarker, 0.4)}
-          blurType="light"
-          opacity={blurOpacity}
-        />
-      </FadeInAnimation>
-    )}
-    <Header justify="space-between">
-      <HeaderButton onPress={onPressSettings}>
-        <Icon name="gear" />
-      </HeaderButton>
-      <BackButton
-        direction="right"
-        onPress={onPressBackButton}
-      />
-    </Header>
-    {areTransactionsFetching && <LoadingOverlay title="Importing..." />}
-    <ActivityList
-      accountAddress={accountAddress}
-      hasPendingTransaction={hasPendingTransaction}
-      header={(
-        <ProfileMasthead
-          accountAddress={accountAddress}
-          navigation={navigation}
-          showBottomDivider={!isEmpty}
-        />
+}) => {
+  // spinner should be displayed if transactions has not been fetched,
+  // AddFundsInterstitial is not displayed (`!isEmpty`) and there's no transaction to be displayed
+  const shouldDisplaySpinner = !areTransactionsFetched && !isEmpty && transactions.length === 0;
+  return (
+    <Page component={FlexItem} style={position.sizeAsObject('100%')}>
+      {showBlur && (
+        <FadeInAnimation duration={200} style={{ ...position.coverAsObject, zIndex: 1 }}>
+          <BlurOverlay
+            backgroundColor={colors.alpha(colors.blueGreyDarker, 0.4)}
+            blurType="light"
+            opacity={blurOpacity}
+          />
+        </FadeInAnimation>
       )}
-      nativeCurrency={nativeCurrency}
-      requests={requests}
-      transactions={transactions}
-      transactionsCount={transactionsCount}
-    />
-    {isEmpty && <AddFundsInterstitial />}
-  </Page>
-);
+      <Header justify="space-between">
+        <HeaderButton onPress={onPressSettings}>
+          <Icon name="gear" />
+        </HeaderButton>
+        <BackButton
+          direction="right"
+          onPress={onPressBackButton}
+        />
+      </Header>
+      {shouldDisplaySpinner && <LoadingOverlay title="Importing..." />}
+      <ActivityList
+        accountAddress={accountAddress}
+        hasPendingTransaction={hasPendingTransaction}
+        header={(
+          <ProfileMasthead
+            accountAddress={accountAddress}
+            navigation={navigation}
+            showBottomDivider={!isEmpty}
+          />
+        )}
+        nativeCurrency={nativeCurrency}
+        requests={requests}
+        transactions={areTransactionsFetched}
+        transactionsCount={transactionsCount}
+      />
+      {isEmpty && <AddFundsInterstitial />}
+    </Page>
+  );
+};
 
 ProfileScreen.propTypes = {
   accountAddress: PropTypes.string,
-  areTransactionsFetching: PropTypes.bool,
+  areTransactionsFetched: PropTypes.bool,
   blurOpacity: PropTypes.object,
   hasPendingTransaction: PropTypes.bool,
   isEmpty: PropTypes.bool,

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -23,52 +23,48 @@ const ProfileScreen = ({
   onPressSettings,
   requests,
   showBlur,
+  showSpinner,
   transactions,
   transactionsCount,
-}) => {
-  // spinner should be displayed if transactions has not been fetched,
-  // AddFundsInterstitial is not displayed (`!isEmpty`) and there's no transaction to be displayed
-  const shouldDisplaySpinner = !areTransactionsFetched && !isEmpty && transactions.length === 0;
-  return (
-    <Page component={FlexItem} style={position.sizeAsObject('100%')}>
-      {showBlur && (
-        <FadeInAnimation duration={200} style={{ ...position.coverAsObject, zIndex: 1 }}>
-          <BlurOverlay
-            backgroundColor={colors.alpha(colors.blueGreyDarker, 0.4)}
-            blurType="light"
-            opacity={blurOpacity}
-          />
-        </FadeInAnimation>
-      )}
-      <Header justify="space-between">
-        <HeaderButton onPress={onPressSettings}>
-          <Icon name="gear" />
-        </HeaderButton>
-        <BackButton
-          direction="right"
-          onPress={onPressBackButton}
+}) => (
+  <Page component={FlexItem} style={position.sizeAsObject('100%')}>
+    {showBlur && (
+      <FadeInAnimation duration={200} style={{ ...position.coverAsObject, zIndex: 1 }}>
+        <BlurOverlay
+          backgroundColor={colors.alpha(colors.blueGreyDarker, 0.4)}
+          blurType="light"
+          opacity={blurOpacity}
         />
-      </Header>
-      {shouldDisplaySpinner && <LoadingOverlay title="Importing..." />}
-      <ActivityList
-        accountAddress={accountAddress}
-        hasPendingTransaction={hasPendingTransaction}
-        header={(
-          <ProfileMasthead
-            accountAddress={accountAddress}
-            navigation={navigation}
-            showBottomDivider={!isEmpty}
-          />
-        )}
-        nativeCurrency={nativeCurrency}
-        requests={requests}
-        transactions={areTransactionsFetched}
-        transactionsCount={transactionsCount}
+      </FadeInAnimation>
+    )}
+    <Header justify="space-between">
+      <HeaderButton onPress={onPressSettings}>
+        <Icon name="gear" />
+      </HeaderButton>
+      <BackButton
+        direction="right"
+        onPress={onPressBackButton}
       />
-      {isEmpty && <AddFundsInterstitial />}
-    </Page>
-  );
-};
+    </Header>
+    {showSpinner && <LoadingOverlay title="Importing..." />}
+    <ActivityList
+      accountAddress={accountAddress}
+      hasPendingTransaction={hasPendingTransaction}
+      header={(
+        <ProfileMasthead
+          accountAddress={accountAddress}
+          navigation={navigation}
+          showBottomDivider={!isEmpty}
+        />
+      )}
+      nativeCurrency={nativeCurrency}
+      requests={requests}
+      transactions={areTransactionsFetched}
+      transactionsCount={transactionsCount}
+    />
+    {isEmpty && <AddFundsInterstitial />}
+  </Page>
+);
 
 ProfileScreen.propTypes = {
   accountAddress: PropTypes.string,
@@ -82,6 +78,7 @@ ProfileScreen.propTypes = {
   onPressSettings: PropTypes.func,
   requests: PropTypes.array,
   showBlur: PropTypes.bool,
+  showSpinner: PropTypes.bool,
   transactions: PropTypes.array,
   transactionsCount: PropTypes.number,
 };

--- a/src/screens/ProfileScreen.js
+++ b/src/screens/ProfileScreen.js
@@ -9,9 +9,11 @@ import { FlexItem, Page } from '../components/layout';
 import { Icon } from '../components/icons';
 import { ProfileMasthead } from '../components/profile';
 import { colors, position } from '../styles';
+import { LoadingOverlay } from '../components/modal';
 
 const ProfileScreen = ({
   accountAddress,
+  areTransactionsFetching,
   blurOpacity,
   hasPendingTransaction,
   isEmpty,
@@ -43,6 +45,7 @@ const ProfileScreen = ({
         onPress={onPressBackButton}
       />
     </Header>
+    {areTransactionsFetching && <LoadingOverlay title="Importing..." />}
     <ActivityList
       accountAddress={accountAddress}
       hasPendingTransaction={hasPendingTransaction}
@@ -64,6 +67,7 @@ const ProfileScreen = ({
 
 ProfileScreen.propTypes = {
   accountAddress: PropTypes.string,
+  areTransactionsFetching: PropTypes.bool,
   blurOpacity: PropTypes.object,
   hasPendingTransaction: PropTypes.bool,
   isEmpty: PropTypes.bool,

--- a/src/screens/ProfileScreenWithData.js
+++ b/src/screens/ProfileScreenWithData.js
@@ -30,7 +30,8 @@ export default compose(
     onPressSettings: ({ navigation }) => () => navigation.navigate('SettingsModal'),
   }),
   withTrackingScreen,
-  withProps(({ isWalletEmpty, transactionsCount }) => ({
+  withProps(({ isWalletEmpty, transactionsCount, areTransactionsFetched }) => ({
     isEmpty: isWalletEmpty && !transactionsCount,
+    showSpinner: !areTransactionsFetched && !isWalletEmpty,
   })),
 )(ProfileScreen);

--- a/src/screens/ProfileScreenWithData.js
+++ b/src/screens/ProfileScreenWithData.js
@@ -14,6 +14,7 @@ import {
   withTrackingScreen,
 } from '../hoc';
 import ProfileScreen from './ProfileScreen';
+import withAreTransactionsFetching from '../hoc/withAreTransactionsFetching';
 
 export default compose(
   setDisplayName('ProfileScreen'),
@@ -22,6 +23,7 @@ export default compose(
   withAccountTransactions,
   withBlurTransitionProps,
   withIsWalletEmpty,
+  withAreTransactionsFetching,
   withRequests,
   withHandlers({
     onPressBackButton: ({ navigation }) => () => navigation.navigate('WalletScreen'),

--- a/src/screens/ProfileScreenWithData.js
+++ b/src/screens/ProfileScreenWithData.js
@@ -14,7 +14,7 @@ import {
   withTrackingScreen,
 } from '../hoc';
 import ProfileScreen from './ProfileScreen';
-import withAreTransactionsFetching from '../hoc/withAreTransactionsFetching';
+import witAreTransactionsFetched from '../hoc/withAreTransactionsFetched';
 
 export default compose(
   setDisplayName('ProfileScreen'),
@@ -23,7 +23,7 @@ export default compose(
   withAccountTransactions,
   withBlurTransitionProps,
   withIsWalletEmpty,
-  withAreTransactionsFetching,
+  witAreTransactionsFetched,
   withRequests,
   withHandlers({
     onPressBackButton: ({ navigation }) => () => navigation.navigate('WalletScreen'),


### PR DESCRIPTION
## Motivation
There're a lot of things happened before making list of transactions visible and especially when there's a lot a them it's reasonable to display a feedback indicating that user is supposed to wait for a while.

## Changes
Some conditions has to be filled in situation when spinner has be to be displayed. Transactions have not to be fetched for the first time, there have to be not loaded from storage (array of them has to be empty) and `AddFundsInterstitial` shouldn't be visible.

I achieved it by hooking into fetching process and tracking state of fetching in store by special hoc. 